### PR TITLE
Introduction of group based privileges.

### DIFF
--- a/demo_files/application/config/flexi_auth.php
+++ b/demo_files/application/config/flexi_auth.php
@@ -122,6 +122,17 @@
 	$config['database']['user_privilege_users']['columns']['user_id'] = 'upriv_users_uacc_fk';
 	$config['database']['user_privilege_users']['columns']['privilege_id'] = 'upriv_users_upriv_fk';
 
+	/**
+	 * User Privilege Groups Table
+	 * The user privilege group table is used to assign privileges to groups. Multiple privileges can be assigned to a group.
+	 * 
+	 * All columns are required.
+	*/ 
+	$config['database']['user_privilege_groups']['table'] = 'user_privilege_groups';
+	$config['database']['user_privilege_groups']['columns']['id'] = 'upriv_groups_id';
+	$config['database']['user_privilege_groups']['columns']['group_id'] = 'upriv_groups_ugrp_fk';
+	$config['database']['user_privilege_groups']['columns']['privilege_id'] = 'upriv_groups_upriv_fk';
+
 	###++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++###
 	
 	/**
@@ -598,6 +609,14 @@
 	 * @param: int
 	*/
 	$config['settings']['default_group_id'] = 1;
+
+        /**
+         * Set which sources are used to retrieve privileges. Can be assigned either through user or group.
+         * @param array
+         * 
+         * Examples: array('user','group'), array('user')
+         */
+        $config['settings']['privilege_sources']= array('user','group');
 
 	
 	###++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++###	

--- a/demo_files/application/controllers/user_guide.php
+++ b/demo_files/application/controllers/user_guide.php
@@ -262,9 +262,9 @@ class User_guide extends CI_Controller {
 	// MISC INFO
 	###++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++###	
 	
-	function misc_info() 
+        function general_settings()  
 	{
-		$this->load->view('user_guide/misc/misc_view');
+		$this->load->view('user_guide/misc/general_settings');
 	}
 }
 /* End of file user_guide.php */

--- a/demo_files/application/models/demo_auth_admin_model.php
+++ b/demo_files/application/models/demo_auth_admin_model.php
@@ -434,6 +434,46 @@ class Demo_auth_admin_model extends CI_Model {
 		// Redirect user.
 		redirect('auth_admin/manage_user_accounts');			
 	}
+
+
+   	/**
+	 * update_group_privileges
+	 * Updates the privileges for a specific group.
+	 */
+   function update_group_privileges($group_id)
+    {
+		// Update privileges.
+		foreach($this->input->post('update') as $row)
+		{
+                    
+			if ($row['current_status'] != $row['new_status'])
+			{
+				// Insert new user privilege.
+				if ($row['new_status'] == 1)
+				{
+					$this->flexi_auth->insert_privilege_group($group_id, $row['id']);	
+				}
+				// Delete existing user privilege.
+				else
+				{
+					$sql_where = array(
+						$this->flexi_auth->db_column('user_privilege_groups', 'group_id') => $group_id,
+						$this->flexi_auth->db_column('user_privilege_groups', 'privilege_id') => $row['id']
+					);
+					
+					$this->flexi_auth->delete_privilege_group($sql_where);
+				}
+			}
+		}
+
+		// Save any public or admin status or error messages to CI's flash session data.
+		$this->session->set_flashdata('message', $this->flexi_auth->get_messages());
+		
+		// Redirect user.
+		redirect('auth_admin/manage_user_groups');			
+    }
+
 }
+
 /* End of file demo_auth_admin_model.php */
 /* Location: ./application/models/demo_auth_admin_model.php */

--- a/demo_files/application/views/demo/admin_examples/group_privileges_update_view.php
+++ b/demo_files/application/views/demo/admin_examples/group_privileges_update_view.php
@@ -25,8 +25,8 @@
 	<div class="content_wrap intro_bg">
 		<div class="content clearfix">
 			<div class="col100">
-				<h2>Admin: Update User Privileges</h2>
-				<p>The flexi auth library allows for unlimited custom user privileges to be defined. The privileges can then be assigned to users on an individual basis.</p>
+				<h2>Admin: Update Group Privileges</h2>
+				<p>The flexi auth library allows for unlimited custom group privileges to be defined. The privileges can then be assigned to groups or users on an individual basis.</p>
 				<p>Once privileges have been defined, access to specific pages or even specific sections of pages can be controlled by checking whether a user has permission to access a requested page.</p>
 				<p>The default setup of this demo uses user groups and privileges to restrict the example public user from accessing the admin area, and the example moderator user from inserting, updating and deleting specific data within the admin area.</p>
                                 <hr/>
@@ -62,9 +62,9 @@
 	<div class="content_wrap main_content_bg">
 		<div class="content clearfix">
 			<div class="col100">
-				<h2>Update User Privileges of <?php echo $user['upro_first_name'].' '.$user['upro_last_name']; ?>, Member of Group <?php echo $user['ugrp_name']; ?></h2>
-				<a href="<?php echo $base_url;?>auth_admin/manage_user_accounts">Manage User Accounts</a> | 
-				<a href="<?php echo $base_url;?>auth_admin/update_user_account/<?php echo $user['upro_uacc_fk']; ?>">Update Users Account</a>
+				<h2>Update Group Privileges of <?php echo $group['ugrp_name']; ?></h2>
+				<a href="<?php echo $base_url;?>auth_admin/manage_user_groups">Manage User Groups</a> | 
+				<a href="<?php echo $base_url;?>auth_admin/update_user_group/<?php echo $group['ugrp_id']; ?>">Update Group</a>
 
 			<?php if (! empty($message)) { ?>
 				<div id="message">
@@ -88,10 +88,6 @@
 									title="If checked, the user will be granted the privilege."/>
 									User Has Privilege
 								</th>
-								<th class="spacer_150 align_ctr tooltip_trigger"
-									title="If checked, the user is granted the privilege through her group."/>
-									Has Privilege From Group
-								</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -105,23 +101,20 @@
 								<td class="align_ctr">
 									<?php 
 										// Define form input values.
-										$current_status = (in_array($privilege[$this->flexi_auth->db_column('user_privileges', 'id')], $user_privileges)) ? 1 : 0; 
-										$new_status = (in_array($privilege[$this->flexi_auth->db_column('user_privileges', 'id')], $user_privileges)) ? 'checked="checked"' : NULL;
+										$current_status = (in_array($privilege[$this->flexi_auth->db_column('user_privileges', 'id')], $group_privileges)) ? 1 : 0; 
+										$new_status = (in_array($privilege[$this->flexi_auth->db_column('user_privileges', 'id')], $group_privileges)) ? 'checked="checked"' : NULL;
 									?>
 									<input type="hidden" name="update[<?php echo $privilege[$this->flexi_auth->db_column('user_privileges', 'id')];?>][current_status]" value="<?php echo $current_status ?>"/>
 									<input type="hidden" name="update[<?php echo $privilege[$this->flexi_auth->db_column('user_privileges', 'id')];?>][new_status]" value="0"/>
 									<input type="checkbox" name="update[<?php echo $privilege[$this->flexi_auth->db_column('user_privileges', 'id')];?>][new_status]" value="1" <?php echo $new_status ?>/>
 								</td>
-                                                                <td class="align_ctr">
-                                                                        <?php echo (in_array($privilege[$this->flexi_auth->db_column('user_privileges', 'id')], $group_privileges) ? 'Yes' : 'No'); ?>
-                                                                </td>
 							</tr>
 						<?php } ?>
 						</tbody>
 						<tfoot>
 							<tr>
-								<td colspan="4">
-									<input type="submit" name="update_user_privilege" value="Update User Privileges" class="link_button large"/>
+								<td colspan="3">
+									<input type="submit" name="update_group_privilege" value="Update Group Privileges" class="link_button large"/>
 								</td>
 							</tr>
 						</tfoot>

--- a/demo_files/application/views/demo/admin_examples/user_group_update_view.php
+++ b/demo_files/application/views/demo/admin_examples/user_group_update_view.php
@@ -38,7 +38,8 @@
 		<div class="content clearfix">
 			<div class="col100">
 				<h2>Update User Group</h2>
-				<a href="<?php echo $base_url;?>auth_admin/manage_user_groups">Manage User Groups</a>
+				<a href="<?php echo $base_url;?>auth_admin/manage_user_groups">Manage User Groups</a> |
+				<a href="<?php echo $base_url;?>auth_admin/update_group_privileges/<?php echo $group['ugrp_id']; ?>">Manage Groups Privileges</a>
 
 			<?php if (! empty($message)) { ?>
 				<div id="message">

--- a/demo_files/application/views/demo/admin_examples/user_groups_view.php
+++ b/demo_files/application/views/demo/admin_examples/user_groups_view.php
@@ -62,6 +62,10 @@
 									title="Indicates whether the group is considered an 'Admin' group.<br/> Note: Privileges can still be set seperately.">
 									Is Admin Group
 								</th>
+								<th class="spacer_100 align_ctr tooltip_trigger"
+									title="Manage the access privileges of groups.">
+									Group Privileges
+								</th>
 								<th class="spacer_100 align_ctr tooltip_trigger" 
 									title="If checked, the row will be deleted upon the form being updated.">
 									Delete
@@ -79,6 +83,9 @@
 								<td><?php echo $group[$this->flexi_auth->db_column('user_group', 'description')];?></td>
 								<td class="align_ctr"><?php echo ($group[$this->flexi_auth->db_column('user_group', 'admin')] == 1) ? "Yes" : "No";?></td>
 								<td class="align_ctr">
+									<a href="<?php echo $base_url.'auth_admin/update_group_privileges/'.$group[$this->flexi_auth->db_column('user_group', 'id')];?>">Manage</a>
+								</td>
+								<td class="align_ctr">
 								<?php if ($this->flexi_auth->is_privileged('Delete User Groups')) { ?>
 									<input type="checkbox" name="delete_group[<?php echo $group[$this->flexi_auth->db_column('user_group', 'id')];?>]" value="1"/>
 								<?php } else { ?>
@@ -91,7 +98,7 @@
 						<?php } ?>
 						</tbody>
 						<tfoot>
-							<td colspan="4">
+							<td colspan="5">
 								<?php $disable = (! $this->flexi_auth->is_privileged('Update User Groups') && ! $this->flexi_auth->is_privileged('Delete User Groups')) ? 'disabled="disabled"' : NULL;?>
 								<input type="submit" name="submit" value="Delete Checked User Groups" class="link_button large" <?php echo $disable; ?>/>
 							</td>

--- a/demo_files/application/views/includes/user_guide_header.php
+++ b/demo_files/application/views/includes/user_guide_header.php
@@ -15,6 +15,9 @@
 						<ul>
 							<li class="header">Internal Auth Config</li>
 						<li>
+							<a href="<?php echo $base_url; ?>user_guide/general_settings">General Settings</a>
+						</li>
+						<li>
 							<a href="<?php echo $base_url; ?>user_guide/login_session_config#user_login_sessions_cookies">Session / Cookie Settings</a>
 						</li>
 						<li>
@@ -44,6 +47,9 @@
 						</li>
 						<li>
 							<a href="<?php echo $base_url; ?>user_guide/user_privilege_config#user_privilege_users_table">User Privilege Users Table</a>
+						</li>
+						<li>
+							<a href="<?php echo $base_url; ?>user_guide/user_privilege_config#user_privilege_groups_table">User Privilege Groups Table</a>
 						</li>
 						<li>
 							<a href="<?php echo $base_url; ?>user_guide/login_session_config#user_login_session_table">User Login Session Table</a>

--- a/demo_files/application/views/user_guide/misc/general_settings.php
+++ b/demo_files/application/views/user_guide/misc/general_settings.php
@@ -1,0 +1,113 @@
+<!doctype html>
+<!--[if lt IE 7 ]><html lang="en" class="no-js ie6"><![endif]-->
+<!--[if IE 7 ]><html lang="en" class="no-js ie7"><![endif]-->
+<!--[if IE 8 ]><html lang="en" class="no-js ie8"><![endif]-->
+<!--[if IE 9 ]><html lang="en" class="no-js ie9"><![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--><html lang="en" class="no-js"><!--<![endif]-->
+<head>
+	<meta charset="utf-8">
+	<title>User Login Session Configuration | User Guide | flexi auth | A User Authentication Library for CodeIgniter</title>
+	<meta name="description" content="The user guide for configuring user login sessions in flexi auth."/> 
+	<meta name="keywords" content="user login session configuration, user guide, flexi auth, user authentication, codeigniter"/>
+	<?php $this->load->view('includes/head'); ?> 
+</head>
+
+<body id="user_guide">
+
+<div id="body_wrap">
+	<!-- Header -->  
+	<?php $this->load->view('includes/header'); ?> 
+
+	<!-- User Guide Navigation -->
+	<?php $this->load->view('includes/user_guide_header'); ?> 
+	
+	<!-- Intro Content -->
+	<div class="content_wrap intro_bg">
+		<div class="content clearfix">
+			<div class="intro_text">
+				<h1>User Guide | General Settings</h1>
+				<p>The key concept of the flexi auth library is to give the developer a toolbox of functions that they can use to build a user authentication system matching the custom specifications required by their site.</p>
+				<p>One of the ways that the library enhances the customisation of the authentication system is by allowing many of the internal library settings to be defined by the developer via the libraries config file.</p>
+			</div>		
+		</div>
+	</div>
+	
+	<!-- Main Content -->
+	<div class="content_wrap main_content_bg">
+		<div class="content clearfix">
+					
+			<h2>General Settings</h2>
+
+			<div class="anchor_nav">
+				<h6>Config Setup Information</h6>
+				<p>
+					<a href="#general_settings">General Config File Settings</a>
+				</p>
+			</div>
+
+			<a name="help"></a>
+			<div class="w100 frame">
+				<h3 class="heading">Help with the Table Configuration</h3>
+				<span class="toggle">Show / Hide Help</span>
+				<div id="help_guide" class="hide_toggle">
+					<hr/>
+					<p><strong>Config Name</strong>: The name that flexi auth internally references the config setting by.</p>
+					<p><strong>Default</strong>: The default value set within the config file.</p>
+					<p>
+						<strong>Data Type</strong>: The data type that is expected by the config setting.
+						<ul>
+							<li><em>bool</em> : Requires a boolean value of 'TRUE' or 'FALSE'.</li>
+							<li><em>string</em> : Requires a textual value.</li>
+							<li><em>int</em> : Requires a numeric value. It does not matter whether the value is an integer, float, decimal etc.</li>
+							<li><em>array</em> : Requires an array.</li>
+							<li><em>datetime</em> : Requires a datetime value. Typically either a MySQL DATETIME (2000-12-31 12:00:00) or UNIX timestamp (1234567890)</li>
+						</ul>
+					</p>
+					<hr/>
+					
+					<h6>Config File Location</h6>
+					<p>The config file is located in CodeIgniters 'config' folder and is named 'flexi_auth.php'.</p>
+				</div>
+			</div>
+
+
+			<a name="general_settings"></a>
+			<div class="w100 frame">
+				<h3 class="heading">General Config File Settings</h3>
+				
+				<p>Many of flexi auths automatic functions are customisable and can even be turned on and off to suit different websites.</p>
+				<hr/>
+
+				
+<pre><span class="comment">// Set whether an incremented number is added to the end of an unavailable username.</span>
+$config['settings']['auto_increment_username'] = FALSE;
+
+<span class="comment">// Set whether accounts are suspended by default on registration / inserting user.</span>
+$config['settings']['suspend_new_accounts'] = FALSE;
+
+<span class="comment">// Set a time limit to grant users instant login access, once expired, they are locked out until they
+activate their account via an activation email sent to them.</span>
+$config['settings']['account_activation_time_limit'] = 0;
+
+<span class="comment">// Set the id of the default group that new users will be added to unless otherwise specified.</span>
+$config['settings']['default_group_id'] = 1;
+
+<span class="comment">// Set which sources are used to retrieve privileges. Can be assigned either through user or group.
+// Demo default: user & group, System default: user only</span>
+$config['settings']['privilege_sources']= array('user','group');
+</pre>
+			</div>
+
+
+		</div>
+	</div>	
+	
+	<!-- Footer -->  
+	<?php $this->load->view('includes/footer'); ?> 
+</div>
+
+<!-- Scripts -->  
+<?php $this->load->view('includes/scripts'); ?> 
+
+</body>
+</html>

--- a/demo_files/application/views/user_guide/user_privilege/user_privilege_get_data_view.php
+++ b/demo_files/application/views/user_guide/user_privilege/user_privilege_get_data_view.php
@@ -44,7 +44,8 @@
 				<h6>User Privilege Data Functions</h6>
 				<p>
 					<a href="#get_privileges">get_privileges()</a> | 
-					<a href="#get_user_privileges">get_user_privileges()</a>
+					<a href="#get_user_privileges">get_user_privileges()</a> | 
+					<a href="#get_group_privileges">get_group_privileges()</a>
 				</p>
 			</div>
 
@@ -243,6 +244,101 @@ $this->flexi_auth->get_user_privileges($sql_select, $sql_where)->result();
 </pre>
 			</div>
 
+                        
+			<a name="get_group_privileges"></a>
+			<div class="w100 frame">
+				<h3 class="heading">get_group_privileges()</h3>
+				
+				<p>Get the user privileges for a group.</p>
+				<hr/>
+				
+				<h6>Library and Requirements</h6>
+				<div class="frame_note">
+					<p>Available via the standard library.</p>
+				</div>
+				
+				<h6>Function Parameters</h6>
+				<code>get_group_privileges(sql_select, sql_where)</code>
+				<a href="#help" class="help_link">Help</a>
+				<table>
+					<thead>
+						<tr>
+							<th class="spacer_150">Name</th>
+							<th class="spacer_100 align_ctr">Data Type</th>
+							<th class="spacer_75 align_ctr">Required</th>
+							<th class="spacer_75 align_ctr">Default</th>
+							<th>Description</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>sql_select</td>
+							<td class="align_ctr">string | array</td>
+							<td class="align_ctr">No</td>
+							<td class="align_ctr">FALSE</td>
+							<td>
+								Define the database fields returned via an SQL SELECT statement.<br/>
+								Read the <a href="<?php echo $base_url; ?>/user_guide/defining_custom_sql">defining SQL documentation</a> for further information.
+							</td>
+						</tr>
+						<tr>
+							<td>sql_where</td>
+							<td class="align_ctr">string | array</td>
+							<td class="align_ctr">No</td>
+							<td class="align_ctr">FALSE</td>
+							<td>
+								<p>
+									Set the SQL WHERE statement used to filter the database records to return.
+									Read the <a href="<?php echo $base_url; ?>/user_guide/defining_custom_sql">defining SQL documentation</a> for further information.
+								</p>
+								<p>
+									If no value is passed to the '<em>sql_where</em>' argument, the function will use the sessions group id to filter privileges for the current logged in user.
+								</p>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				
+				<h6>How it Works</h6>
+				<div class="frame_note">
+					<p>The function runs an SQL SELECT query that joins the User Privilege and User Privilege Groups table together.</p>
+					<p>The function uses the defined '<em>sql_where</em>' argument to create an SQL WHERE statement to filter a list of user privileges.</p>
+					<p>If no value is passed to the '<em>sql_where</em>' argument, the function will use the sessions user id to filter privileges for the current logged in user.</p>
+					<p>The data returned by the query is defined via the '<em>sql_select</em>' argument. If no columns are specified, all columns will be returned.</p>
+				</div>
+				
+				<h6>Notes</h6>
+				<div class="frame_note">
+					<p>This function is compatible with flexi auths '<a href="<?php echo $base_url; ?>user_guide/custom_sql_query_builder">Query Builder</a>' functions.</p>
+					<hr/>
+					<p>This function can be chained with CodeIgniters query functions 'result()', 'row()' etc.</p>
+					<p>Read the <a href="<?php echo $base_url; ?>user_guide/query_sql_results">Query Result documentation</a> for further information on all the combined flexi auth and CodeIgniter functions that are available.</p>
+				</div>
+						
+				<h6>Return Values</h6>
+				<div class="frame_note">
+					<p><strong class="spacer_100">Failure:</strong>FALSE</p>
+					<p><strong class="spacer_100">Success:</strong>object</p>
+				</div>
+				
+				<h6>Examples</h6>
+<pre>
+<span class="comment">// Example #1 : Using the session group id of a logged in user.</span>
+$this->flexi_auth->get_group_privileges(FALSE, FALSE);
+</pre>
+<pre>
+<span class="comment">// Example #2 : Defining a specific SQL WHERE condition and specific columns to return.
+// Read the <a href="<?php echo $base_url; ?>user_guide/defining_custom_sql">defining SQL documentation</a> for further information on setting SQL statements.</span>
+$sql_select = array(...);
+$sql_where = array(...);
+
+<span class="comment">// Example of chaining CI's query function 'result()'.
+// Read the <a href="<?php echo $base_url; ?>user_guide/query_sql_results">Query Result documentation</a> for further information on available functions.</span>
+$this->flexi_auth->get_group_privileges($sql_select, $sql_where)->result();
+</pre>
+			</div>
+
+                        
 		</div>
 	</div>	
 	

--- a/demo_files/application/views/user_guide/user_privilege/user_privilege_index_view.php
+++ b/demo_files/application/views/user_guide/user_privilege/user_privilege_index_view.php
@@ -63,6 +63,10 @@
 						<a href="<?php echo $base_url; ?>user_guide/user_privilege_get_data#get_user_privileges">get_user_privileges()</a><br/>
 						<small>Get the user privileges for a user.</small>
 					</li>
+					<li>
+						<a href="<?php echo $base_url; ?>user_guide/user_privilege_get_data#get_group_privileges">get_group_privileges()</a><br/>
+						<small>Get the group privileges for a group.</small>
+					</li>
 				</ul>
 				<hr/>
 				
@@ -101,6 +105,14 @@
 					<li>
 						<a href="<?php echo $base_url; ?>user_guide/user_privilege_set_data#delete_privilege_user">delete_privilege_user()</a><br/>
 						<small>Deletes a user privilege for a user.</small>
+					</li>
+					<li>
+						<a href="<?php echo $base_url; ?>user_guide/user_privilege_set_data#insert_privilege_group">insert_privilege_group()</a><br/>
+						<small>Inserts a new user privilege for a group.</small>
+					</li>
+					<li>
+						<a href="<?php echo $base_url; ?>user_guide/user_privilege_set_data#delete_privilege_group">delete_privilege_group()</a><br/>
+						<small>Deletes a user privilege for a group.</small>
 					</li>
 				</ul>
 			</div>

--- a/demo_files/application/views/user_guide/user_privilege/user_privilege_set_data_view.php
+++ b/demo_files/application/views/user_guide/user_privilege/user_privilege_set_data_view.php
@@ -47,7 +47,9 @@
 					<a href="#update_privilege">update_privilege()</a> | 
 					<a href="#delete_privilege">delete_privilege()</a> |
 					<a href="#insert_privilege_user">insert_privilege_user()</a> | 
-					<a href="#delete_privilege_user">delete_privilege_user()</a>
+					<a href="#delete_privilege_user">delete_privilege_user()</a> |
+					<a href="#insert_privilege_group">insert_privilege_group()</a> | 
+					<a href="#delete_privilege_group">delete_privilege_group()</a>
 				</p>
 			</div>
 
@@ -423,7 +425,142 @@ $sql_where = array(...);
 $this->flexi_auth->delete_privilege_user($sql_where);
 </pre>
 			</div>
+                        
 
+			<a name="insert_privilege_group"></a>
+			<div class="w100 frame">
+				<h3 class="heading">insert_privilege_group()</h3>
+				
+				<p>Inserts a new user privilege for a group.</p>
+				<hr/>
+				
+				<h6>Library and Requirements</h6>
+				<div class="frame_note">
+					<p>Available via the standard library.</p>
+				</div>
+				
+				<h6>Function Parameters</h6>
+				<code>insert_privilege_group(group_id, privilege_id)</code>
+				<a href="#help" class="help_link">Help</a>
+				<table>
+					<thead>
+						<tr>
+							<th class="spacer_150">Name</th>
+							<th class="spacer_100 align_ctr">Data Type</th>
+							<th class="spacer_75 align_ctr">Required</th>
+							<th class="spacer_75 align_ctr">Default</th>
+							<th>Description</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>group_id</td>
+							<td class="align_ctr">int</td>
+							<td class="align_ctr">Yes</td>
+							<td class="align_ctr">FALSE</td>
+							<td>Defines the id of the group to insert a new user privilege for.</td>
+						</tr>
+						<tr>
+							<td>privilege_id</td>
+							<td class="align_ctr">int</td>
+							<td class="align_ctr">Yes</td>
+							<td class="align_ctr">FALSE</td>
+							<td>Defines the id of the user privilege to be inserted for a group.</td>
+						</tr>
+					</tbody>
+				</table>
+				
+				<h6>How it Works</h6>
+				<div class="frame_note">
+					<p>The function runs an SQL INSERT query inserting the '<em>group_id</em>' and '<em>privilege_id</em>' to the User Privilege Groups table.</p>
+				</div>
+									
+				<h6>Return Values</h6>
+				<div class="frame_note">
+					<p><strong class="spacer_100">Failure:</strong>FALSE | An error message will be set.</p>
+					<p><strong class="spacer_100">Success:</strong>TRUE | id of new record | A status message will be set.</p>
+				</div>
+				
+				<h6>Example</h6>
+<pre>
+<span class="comment">// Example of applying a user privilege to a specific group.</span>
+$group_id = 3;
+$privilege_id = 201;
+
+$this->flexi_auth->insert_privilege_group($group_id, $privilege_id);
+</pre>
+			</div>
+
+			<a name="delete_privilege_group"></a>
+			<div class="w100 frame">
+				<h3 class="heading">delete_privilege_group()</h3>
+				
+				<p>Deletes a user privilege for a group.</p>
+				<hr/>
+				
+				<h6>Library and Requirements</h6>
+				<div class="frame_note">
+					<p>Available via the standard library.</p>
+				</div>
+				
+				<h6>Function Parameters</h6>
+				<code>delete_privilege_group(sql_where)</code>
+				<a href="#help" class="help_link">Help</a>
+				<table>
+					<thead>
+						<tr>
+							<th class="spacer_150">Name</th>
+							<th class="spacer_100 align_ctr">Data Type</th>
+							<th class="spacer_75 align_ctr">Required</th>
+							<th class="spacer_75 align_ctr">Default</th>
+							<th>Description</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>sql_where</td>
+							<td class="align_ctr">string | int | array</td>
+							<td class="align_ctr">No</td>
+							<td class="align_ctr">FALSE</td>
+							<td>
+								<p>
+									Set the SQL WHERE statement used to filter the database records to return.
+									Read the <a href="<?php echo $base_url; ?>/user_guide/defining_custom_sql">defining SQL documentation</a> for further information.
+								</p>
+								<p>
+									If a number is passed, the function will interpret the value as the tables primary key. 		
+								</p>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				
+				<h6>How it Works</h6>
+				<div class="frame_note">
+					<p>The function generates an SQL WHERE statement from the passed '<em>sql_where</em>' argument and deletes all matching user privilege users.</p>
+				</div>
+									
+				<h6>Return Values</h6>
+				<div class="frame_note">
+					<p><strong class="spacer_100">Failure:</strong>FALSE | An error message will be set.</p>
+					<p><strong class="spacer_100">Success:</strong>TRUE | A status message will be set.</p>
+				</div>
+				
+				<h6>Examples</h6>
+<pre>
+<span class="comment">// Example #1 : Delete a user privilege group via a user privilege group id of 101.</span>
+$sql_where = 101;
+
+$this->flexi_auth->delete_privilege_group($sql_where);
+</pre>
+<pre>
+<span class="comment">// Example #2 : Delete user privilege groups via a custom SQL WHERE statement.</span>
+<span class="comment">// Read the <a href="<?php echo $base_url; ?>user_guide/defining_custom_sql">defining SQL documentation</a> for further information on setting SQL statements.</span>
+$sql_where = array(...);
+
+$this->flexi_auth->delete_privilege_group($sql_where);
+</pre>
+			</div>
 
 		</div>
 	</div>	

--- a/demo_files/application/views/user_guide_view.php
+++ b/demo_files/application/views/user_guide_view.php
@@ -91,6 +91,9 @@
 						<a href="<?php echo $base_url; ?>user_guide/user_privilege_config#user_privilege_users_table">User Privilege Users Table</a>
 					</li>
 					<li>
+						<a href="<?php echo $base_url; ?>user_guide/user_privilege_config#user_privilege_groups_table">User Privilege Groups Table</a>
+					</li>
+					<li>
 						<a href="<?php echo $base_url; ?>user_guide/login_session_config#user_login_session_table">User Login Session Table</a>
 					</li>
 				</ul>

--- a/demo_files/sql_dump/flexi_auth_demo_database_dump.sql
+++ b/demo_files/sql_dump/flexi_auth_demo_database_dump.sql
@@ -219,3 +219,38 @@ INSERT INTO `user_privilege_users` VALUES ('12', '2', '1');
 INSERT INTO `user_privilege_users` VALUES ('13', '2', '2');
 INSERT INTO `user_privilege_users` VALUES ('14', '2', '3');
 INSERT INTO `user_privilege_users` VALUES ('15', '2', '6');
+
+
+-- ----------------------------
+-- Table structure for `user_privilege_groups`
+-- ----------------------------
+
+DROP TABLE IF EXISTS `user_privilege_groups`;
+CREATE TABLE `user_privilege_groups` (
+  `upriv_groups_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `upriv_groups_ugrp_fk` smallint(5) unsigned NOT NULL,
+  `upriv_groups_upriv_fk` smallint(5) unsigned NOT NULL,
+  PRIMARY KEY (`upriv_groups_id`),
+  UNIQUE KEY `upriv_groups_id` (`upriv_groups_id`) USING BTREE,
+  KEY `upriv_groups_ugrp_fk` (`upriv_groups_ugrp_fk`),
+  KEY `upriv_groups_upriv_fk` (`upriv_groups_upriv_fk`)
+) ENGINE=InnoDB  DEFAULT CHARSET=latin1 AUTO_INCREMENT=15 ;
+
+
+-- ----------------------------
+-- Records of user_privilege_groups
+-- ----------------------------
+
+INSERT INTO `user_privilege_groups` VALUES(1, 3, 1);
+INSERT INTO `user_privilege_groups` VALUES(3, 3, 3);
+INSERT INTO `user_privilege_groups` VALUES(4, 3, 4);
+INSERT INTO `user_privilege_groups` VALUES(5, 3, 5);
+INSERT INTO `user_privilege_groups` VALUES(6, 3, 6);
+INSERT INTO `user_privilege_groups` VALUES(7, 3, 7);
+INSERT INTO `user_privilege_groups` VALUES(8, 3, 8);
+INSERT INTO `user_privilege_groups` VALUES(9, 3, 9);
+INSERT INTO `user_privilege_groups` VALUES(10, 3, 10);
+INSERT INTO `user_privilege_groups` VALUES(11, 3, 11);
+INSERT INTO `user_privilege_groups` VALUES(12, 2, 2);
+INSERT INTO `user_privilege_groups` VALUES(13, 2, 4);
+INSERT INTO `user_privilege_groups` VALUES(14, 2, 5);

--- a/library_files/application/config/flexi_auth.php
+++ b/library_files/application/config/flexi_auth.php
@@ -121,6 +121,17 @@
 	$config['database']['user_privilege_users']['columns']['id'] = 'upriv_users_id';
 	$config['database']['user_privilege_users']['columns']['user_id'] = 'upriv_users_uacc_fk';
 	$config['database']['user_privilege_users']['columns']['privilege_id'] = 'upriv_users_upriv_fk';
+	
+	/**
+	 * User Privilege Groups Table
+	 * The user privilege group table is used to assign privileges to groups. Multiple privileges can be assigned to a group.
+	 * 
+	 * All columns are required.
+	*/ 
+	$config['database']['user_privilege_groups']['table'] = 'user_privilege_groups';
+	$config['database']['user_privilege_groups']['columns']['id'] = 'upriv_groups_id';
+	$config['database']['user_privilege_groups']['columns']['group_id'] = 'upriv_groups_ugrp_fk';
+	$config['database']['user_privilege_groups']['columns']['privilege_id'] = 'upriv_groups_upriv_fk';
 
 	###++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++###
 	
@@ -563,6 +574,16 @@
 	 * @param: int
 	*/
 	$config['settings']['default_group_id'] = 1;
+        
+        /**
+         * Set which sources are used to retrieve privileges. Can be assigned either through user or group.
+         * @param array
+         * 
+         * Examples: array('user','group'), array('user')
+         * 
+         * Default: individual user privileges only
+         */
+        $config['settings']['privilege_sources']= array('user');
 
 	
 	###++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++###	

--- a/library_files/application/libraries/Flexi_auth.php
+++ b/library_files/application/libraries/Flexi_auth.php
@@ -876,6 +876,26 @@ class Flexi_auth extends Flexi_auth_lite
 		$this->CI->flexi_auth_model->set_error_message('update_unsuccessful', 'config');
 		return FALSE;
 	}
+        
+        
+	/**
+	 * insert_privilege_group
+	 * Inserts a new user privilege group to the database.
+	 *
+	 * @return void
+	 * @author Rob Hussey (Copy/Paste by: Filou Tschiemer)
+	 */
+	public function insert_privilege_group($group_id, $privilege_id)
+	{
+		if ($privilege_id = $this->CI->flexi_auth_model->insert_privilege_group($group_id, $privilege_id));
+		{
+			$this->CI->flexi_auth_model->set_status_message('update_successful', 'config');
+			return $privilege_id;
+		}
+
+		$this->CI->flexi_auth_model->set_error_message('update_unsuccessful', 'config');
+		return FALSE;
+	}
 	
 	/**
 	 * delete_privilege_user
@@ -887,6 +907,26 @@ class Flexi_auth extends Flexi_auth_lite
 	public function delete_privilege_user($sql_where)
 	{
 		if ($this->CI->flexi_auth_model->delete_privilege_user($sql_where))
+		{
+			$this->CI->flexi_auth_model->set_status_message('delete_successful', 'config');
+			return TRUE;
+		}
+
+		$this->CI->flexi_auth_model->set_error_message('delete_unsuccessful', 'config');
+		return FALSE;
+	}
+        
+        
+	/**
+	 * delete_privilege_group
+	 * Deletes a group from the user privilege group table.
+	 *
+	 * @return bool
+	 * @author Rob Hussey (Copy/Paste by: Filou Tschiemer)
+	 */
+	public function delete_privilege_group($sql_where)
+	{
+		if ($this->CI->flexi_auth_model->delete_privilege_group($sql_where))
 		{
 			$this->CI->flexi_auth_model->set_status_message('delete_successful', 'config');
 			return TRUE;
@@ -1034,6 +1074,25 @@ class Flexi_auth extends Flexi_auth_lite
 		}
 	
 		return $this->CI->flexi_auth_model->get_user_privileges($sql_select, $sql_where);
+	}
+        
+        
+	/**
+	 * get_group_privileges_query
+	 * Returns a groups privileges using their session group_id by default.
+	 *
+	 * @return object
+	 * @author Rob Hussey (Copy/Paste by: Filou Tschiemer)
+	 */
+	public function get_group_privileges_query($sql_select = FALSE, $sql_where = FALSE)
+	{
+		if (! $sql_where)
+		{
+			$sql_where = array($this->CI->auth->tbl_col_user_privilege_groups['group'] => 
+				$this->CI->auth->session_data[$this->CI->auth->session_name['group']]);
+		}
+	
+		return $this->CI->flexi_auth_model->get_group_privileges($sql_select, $sql_where);
 	}
 
 	

--- a/library_files/application/models/flexi_auth_lite_model.php
+++ b/library_files/application/models/flexi_auth_lite_model.php
@@ -118,6 +118,10 @@ class Flexi_auth_lite_model extends CI_Model
 		$this->auth->tbl_user_privilege_users = $database_config['user_privilege_users']['table'];
 		$this->auth->tbl_col_user_privilege_users = $database_config['user_privilege_users']['columns'];
 		
+		// Group privilege tables
+		$this->auth->tbl_user_privilege_groups = $database_config['user_privilege_groups']['table'];
+		$this->auth->tbl_col_user_privilege_groups = $database_config['user_privilege_groups']['columns'];
+		
 		// User main account table
 		$this->auth->tbl_user_account = $database_config['user_acc']['table'];
 		$this->auth->tbl_join_user_account = $database_config['user_acc']['join'];

--- a/library_files/sql_dump/flexi_auth_database_dump.sql
+++ b/library_files/sql_dump/flexi_auth_database_dump.sql
@@ -136,3 +136,23 @@ CREATE TABLE `user_privilege_users` (
 -- ----------------------------
 -- Records of user_privilege_users
 -- ----------------------------
+
+
+-- ----------------------------
+-- Table structure for `user_privilege_groups`
+-- ----------------------------
+
+DROP TABLE IF EXISTS `user_privilege_groups`;
+CREATE TABLE `user_privilege_groups` (
+  `upriv_groups_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `upriv_groups_ugrp_fk` smallint(5) unsigned NOT NULL,
+  `upriv_groups_upriv_fk` smallint(5) unsigned NOT NULL,
+  PRIMARY KEY (`upriv_groups_id`),
+  UNIQUE KEY `upriv_groups_id` (`upriv_groups_id`) USING BTREE,
+  KEY `upriv_groups_ugrp_fk` (`upriv_groups_ugrp_fk`),
+  KEY `upriv_groups_upriv_fk` (`upriv_groups_upriv_fk`)
+) ENGINE=InnoDB  DEFAULT CHARSET=latin1 AUTO_INCREMENT=1;
+
+-- ----------------------------
+-- Records of user_privilege_groups
+-- ----------------------------


### PR DESCRIPTION
Motivation for the group based/assigned privileges:
I have a potentially large and changing userbase, so assigning privileges individually is not an option; as it would be both a hassle (for the admins) and a potential error source (which we really don't want).

The user roles would be rather static so group based access would be the approach to go.

On the other hand the functionality and access is rather widespread and fine-grained  so privileges would be better suited for this (ie. changes mean hassle for the developer - yeah right, might get paid for that).

So assigning privileges to groups gives the advantages of both approaches, ease of managability for admin and dev.

The functionality is configurable such that any of group privileges and/or/neither user privileges are actually loaded, ie. it is possible to deactivate the loading of the privileges altogether leaving only the group membership based access control functioning, if so desired.

Codewise mostly a duplicate of the original methods ment for querying and changing the user privileges; for users it just means an additional query during login, for devs it's use as is.

Demo/userguide extended accordingly..
