### PR TITLE
Minor bug in get_messages() in flexi_auth_lite_model.php

### DIFF
--- a/library_files/application/models/flexi_auth_lite_model.php
+++ b/library_files/application/models/flexi_auth_lite_model.php
@@ -573,12 +573,12 @@ class Flexi_auth_lite_model extends CI_Model
 			$target_user = strtolower($target_user);
 
 			// Set message delimiters, by checking they do not exactly equal FALSE, we can allow NULL or empty '' delimiter values. 
-			if (! $prefix_delimiter)
+			if ($prefix_delimiter!=FALSE)
 			{
 				$prefix_delimiter = ($message_type == 'status') ? 
 					$this->auth->message_settings['delimiters']['status_prefix'] : $this->auth->message_settings['delimiters']['error_prefix'];
 			}
-			if (! $suffix_delimiter)
+			if ($suffix_delimiter!=FALSE)
 			{
 				$suffix_delimiter = ($message_type == 'status') ? 
 					$this->auth->message_settings['delimiters']['status_suffix'] : $this->auth->message_settings['delimiters']['error_suffix'];


### PR DESCRIPTION
Hi

There is a minor issue in the status_message() an error_message(). Even if the prefix_delimiter and suffix_delimiter are set to false, the library wraps it with the delimiters in the config file.

To fix it on line 577 of get_messages()

``` php
if (! prefix_delimiter)
```

needs to be

``` php
if ($prefix_delimiter!=FALSE)
```

and the same for if (! $suffix_delimiter)
