### PR TITLE
Missing param $config in MY_Form_validation constructor

### DIFF
--- a/library_files/application/libraries/MY_Form_validation.php
+++ b/library_files/application/libraries/MY_Form_validation.php
@@ -2,9 +2,9 @@
 
 class MY_Form_validation extends CI_Form_validation 
 {
-	public function __construct()
+	public function __construct($config)
 	{
-		parent::__construct();
+		parent::__construct($config);
 	}
 
     // Check identity is available


### PR DESCRIPTION
This param is needed for working correctly with validation rules defined inside a config file /application/config/form_validation.php .
