### PR TITLE
Fixes CI's automatic associating of controller functions with validation rule groups when using flexi-auth.

### DIFF
--- a/library_files/application/libraries/MY_Form_validation.php
+++ b/library_files/application/libraries/MY_Form_validation.php
@@ -2,9 +2,9 @@
 
 class MY_Form_validation extends CI_Form_validation 
 {
-	public function __construct()
+	public function __construct($rules = array())
 	{
-		parent::__construct();
+		parent::__construct($rules);
 	}
 
     // Check identity is available


### PR DESCRIPTION
This fixes automatic associating of controller functions with rule groups.
See:
- http://ellislab.com/forums/viewthread/181888/
- http://ellislab.com/codeigniter/user-guide/libraries/form_validation.html#savingtoconfig
