### PR TITLE
Custom user columns on user insertion fix

### DIFF
--- a/library_files/application/models/flexi_auth_model.php
+++ b/library_files/application/models/flexi_auth_model.php
@@ -196,14 +196,17 @@ class Flexi_auth_model extends Flexi_auth_lite_model
 	    }
 
 		// Loop through custom data columns for the main user table set via config file.
-		foreach($this->auth->tbl_custom_col_user_account as $column)
-		{			
-			if (array_key_exists($column, $custom_data))
-			{
-				$sql_insert[$column] = $custom_data[$column];
-				unset($custom_data[$column]);
-			}
-		}
+                if ( is_array($custom_data))
+                {
+                    foreach($this->auth->tbl_custom_col_user_account as $column)
+                    {			
+                            if (array_key_exists($column, $custom_data))
+                            {
+                                    $sql_insert[$column] = $custom_data[$column];
+                                    unset($custom_data[$column]);
+                            }
+                    }
+                }
 
 	    // Create main user account.
 		$this->db->insert($this->auth->tbl_user_account, $sql_insert);


### PR DESCRIPTION
Problem: 

Having defined custom columns for the user account table and attempting to insert a user passing the default value FALSE for the custom_data argument raises an error:

PHP Error: array_key_exists() expects parameter 2 to be array, boolean given in /ci/application/models/flexi_auth_model.php, line 204

Fix:

sanity check :)
