### PR TITLE
Match `MY_Form_validation` constructor call signature with parent class

### DIFF
--- a/library_files/application/libraries/MY_Form_validation.php
+++ b/library_files/application/libraries/MY_Form_validation.php
@@ -2,9 +2,9 @@
 
 class MY_Form_validation extends CI_Form_validation 
 {
-	public function __construct()
+	public function __construct($rules = array())
 	{
-		parent::__construct();
+		parent::__construct($rules);
 	}
 
     // Check identity is available

--- a/readme.txt
+++ b/readme.txt
@@ -10,5 +10,3 @@ flexi auth Concept: http://haseydesign.com/flexi-auth/user_guide/concept/
 Library Overview: http://haseydesign.com/flexi-auth/
 Library Demo: http://haseydesign.com/flexi-auth/auth_lite/demo/
 Library User Guide: http://haseydesign.com/flexi-auth/user_guide/
-
-Support : http://ellislab.com/forums/viewthread/224351/


### PR DESCRIPTION
Adding this change allowed me to use validation rules that are defined in a global configuration file as described in https://ellislab.com/codeIgniter/user-guide/libraries/form_validation.html. I'm not sure if the absence of the argument is intentional, but I feel matching the call signature of a class that is inherited from is a good thing overall.
